### PR TITLE
Use camelCase for Git config keys (closes #5)

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -250,14 +250,14 @@
 
 [core]
     # Global `.gitattributes`
-    attributesfile = ~/git/.gitattributes
+    attributesFile = ~/git/.gitattributes
 
     # Default editor for commit messages and other inputs
     # Even when EDITOR is set to something else
     editor=vim
 
     # Global `.gitignore`
-    excludesfile = ~/git/.gitignore_global
+    excludesFile = ~/git/.gitignore_global
 
     pager = delta
 
@@ -330,7 +330,7 @@
 
 [help]
     # Automatically correct and execute mistyped commands
-    autocorrect = 2
+    autoCorrect = 2
 
 [gpg]
     program = gpg
@@ -438,7 +438,7 @@
     # Reuse recorded resolutions
     enabled = true
 
-    autoupdate = true
+    autoUpdate = true
 
 [status]
     # Show all untracked files in untracked directories


### PR DESCRIPTION
Closes #5.

Git config variable names are case-insensitive, so this is a pure readability change — no behaviour changes. Follows Git's own convention from [git/git da0005b8 — *"doc: stick to camelCase naming convention"*](https://github.com/git/git/commit/da0005b8853137c91e44867d899910d5c7eb4425), as referenced by [mathiasbynens/dotfiles#924](https://github.com/mathiasbynens/dotfiles/pull/924).

### Changed
- `core.attributesfile` → `core.attributesFile`
- `core.excludesfile` → `core.excludesFile`
- `help.autocorrect` → `help.autoCorrect`
- `rerere.autoupdate` → `rerere.autoUpdate`

### Deliberately left lowercase
- `core.trustctime` — Git keeps this one (and `core.autocrlf`, `core.safecrlf`, `diff.dirstat`, …) lowercase in that same commit, so I left it as-is.
- `diff.<driver>.xfuncname` — Git's own docs keep it lowercase.

The `[alias]` entries are user-defined command names, not Git built-in keys, so they're untouched.

### Verification
`git config --list` parses, and every key resolves under the new casing (`git config --get core.excludesFile` → `~/git/.gitignore_global`, `help.autoCorrect` → `2`, `rerere.autoUpdate` → `true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)