### PR TITLE
Brewfile: add mole (tw93/Mole)

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -83,6 +83,7 @@ brew 'jsonlint'
 brew 'tdewolff/tap/minify'
 brew 'minio'
 brew 'mise' # unified runtime manager (Ruby, Node, …) — replaces rbenv & nvm
+brew 'mole' # tw93/Mole — deep clean & optimise the Mac (the .bash_profile completion)
 brew 'node' # This installs `npm` too using the recommended installation method
 brew 'optipng'
 brew 'p7zip'


### PR DESCRIPTION
`.bash_profile` already runs `mole completion bash`, but `mole` was never in the Brewfile, so on a fresh machine that line was a silent no-op.

`mole` is [tw93/Mole](https://github.com/tw93/Mole) ("Deep clean and optimize your Mac") and lives in homebrew-core (homepage mole.fit), so no custom tap or tap-trust is needed — just `brew 'mole'`.

Installed locally and confirmed `mole completion bash` now works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)