### PR TITLE
Add apple/container as the Linux container runtime

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -49,6 +49,7 @@ brew 'bat'
 brew 'bfg'
 brew 'cloc'
 brew 'cmake'
+brew 'container' # apple/container — run Linux containers in lightweight VMs (Apple Silicon, macOS 26+)
 brew 'csvkit'
 brew 'ctags'
 brew 'direnv'

--- a/init/install.sh
+++ b/init/install.sh
@@ -114,6 +114,17 @@ fi
 # commit-graph, prefetch). Run the same in any other repo you want kept tidy.
 git -C "$DOTFILES" maintenance start 2>/dev/null || true
 
+# ========= Linux container runtime (apple/container) ==========
+
+# Start Apple's `container` service and install its default kernel so Linux
+# containers work out of the box (Apple Silicon + macOS 26+). Idempotent;
+# tolerate older hardware/OS where it isn't available. For an always-on service
+# at login instead, use `brew services start container`.
+if command -v container >/dev/null 2>&1; then
+    echo "Starting the Apple container runtime…"
+    container system start --enable-kernel-install || true
+fi
+
 # ========= macOS system preferences =========
 
 # Apply this setup's macOS defaults (Dock, Finder, trackpad, Mission Control,


### PR DESCRIPTION
Sets up [apple/container](https://github.com/apple/container) — Apple's native tool for running Linux containers in lightweight per-container VMs on Apple Silicon.

## Changes
- **Brewfile:** `brew 'container'` — it's in homebrew-core (Apache-2.0, v1.0.0), so no tap/`.pkg` needed.
- **install.sh:** after `brew bundle`, runs `container system start --enable-kernel-install` to start the service and fetch the default kernel non-interactively. Guarded by `command -v` and `|| true`, so it's a no-op on hardware/OS that can't run it (needs Apple Silicon + macOS 26+).

## Verified locally
- `container --version` → 1.0.0
- `container system status` → running
- `container run --rm docker.io/library/alpine uname -sm` → **`Linux aarch64`** ✅

## Notes
- `install.sh` starts it for the current session. If you'd rather have it always running at login, use `brew services start container` (didn't enable that by default to avoid an always-on VM helper).
- Didn't add `container-compose` (the compose-style wrapper) — say the word if you want it alongside your existing `docker-compose`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)