### PR TITLE
Wrap Claude Code through Headroom (memory + code graph)

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -6,7 +6,10 @@ alias .....="cd ../../../.."
 
 # Shortcuts
 alias c="cursor"
-alias cc="claude --allow-dangerously-skip-permissions"
+# Claude Code wrapped through Headroom: routes API calls through its proxy for
+# context compression, with persistent cross-session memory and code-graph
+# intelligence. `--` forwards the rest to claude itself.
+alias cc="headroom wrap claude --memory --code-graph -- --allow-dangerously-skip-permissions"
 alias d="cd ~/Documents"
 alias dl="cd ~/Downloads"
 alias dt="cd ~/Desktop"

--- a/Brewfile
+++ b/Brewfile
@@ -92,6 +92,8 @@ brew 'pigz'
 brew 'postgresql'
 brew 'pv'
 brew 'python3'
+brew 'pipx' # install & run Python CLI apps in isolated venvs (e.g. headroom-ai)
+brew 'uv' # fast Python pkg/installer; provides uvx for headroom's Serena MCP
 brew 'rename'
 brew 'ssh-copy-id', link: true
 brew 'opentofu'

--- a/init/install.sh
+++ b/init/install.sh
@@ -114,6 +114,41 @@ fi
 # commit-graph, prefetch). Run the same in any other repo you want kept tidy.
 git -C "$DOTFILES" maintenance start 2>/dev/null || true
 
+# ========= Headroom (Claude Code context compression) ==========
+
+# Install the headroom CLI from PyPI into its own pipx-managed venv (Python,
+# not the Docker image). pipx itself comes from the Brewfile. The `cc` alias in
+# ~/.aliases runs `headroom wrap claude … --memory --code-graph`. Idempotent —
+# pipx skips an already-installed package.
+if command -v pipx >/dev/null 2>&1; then
+    echo "Installing the headroom CLI…"
+    pipx install "headroom-ai[all]" || true
+fi
+
+# Pre-install the code-graph backend (codebase-memory-mcp). headroom 0.27 pins
+# v0.6.0, whose release has no published binaries (404), so its auto-download
+# fails. headroom probes ~/.local/bin first, so drop a working build there to
+# take over. Serena (the other --code-graph helper) runs via uvx from the
+# Brewfile's `uv`. Bump CBM_VER as new tagged binaries ship.
+CBM_VER="v0.8.1"
+CBM_BIN="$HOME/.local/bin/codebase-memory-mcp"
+if [ ! -x "$CBM_BIN" ]; then
+    case "$(uname -m)" in
+        arm64 | aarch64) CBM_ARCH="darwin-arm64" ;;
+        *) CBM_ARCH="darwin-amd64" ;;
+    esac
+    CBM_URL="https://github.com/DeusData/codebase-memory-mcp/releases/download/${CBM_VER}/codebase-memory-mcp-${CBM_ARCH}.tar.gz"
+    echo "Installing codebase-memory-mcp ${CBM_VER} (${CBM_ARCH})…"
+    CBM_TMP="$(mktemp -d)"
+    if curl -fsSL "$CBM_URL" -o "$CBM_TMP/cbm.tar.gz" && tar -xzf "$CBM_TMP/cbm.tar.gz" -C "$CBM_TMP"; then
+        mkdir -p "$HOME/.local/bin"
+        install -m 0755 "$(find "$CBM_TMP" -type f -name codebase-memory-mcp | head -1)" "$CBM_BIN"
+    else
+        echo "  codebase-memory-mcp download failed — skipping (code graph stays off)."
+    fi
+    rm -rf "$CBM_TMP"
+fi
+
 # ========= Linux container runtime (apple/container) ==========
 
 # Start Apple's `container` service and install its default kernel so Linux


### PR DESCRIPTION
## What

Install [Headroom](https://github.com/headroomlabs-ai/headroom) and route the `cc` alias through it so Claude Code runs with context compression, persistent cross-session memory, and code-graph intelligence.

Headroom is installed from PyPI via **pipx (Python binary), not the Docker image**.

## Changes

- **`.aliases`** — `cc` now runs:
  ```sh
  headroom wrap claude --memory --code-graph -- --allow-dangerously-skip-permissions
  ```
  `--` forwards the permission flag to `claude` itself.
- **`Brewfile`** — add `pipx` (isolated venv for `headroom-ai`) and `uv` (provides `uvx`, needed for Headroom's Serena MCP).
- **`init/install.sh`** — pipx-install `headroom-ai[all]`, then pre-install the code-graph backend `codebase-memory-mcp` into `~/.local/bin`.

## Why the extra code-graph step

Headroom 0.27 hardcodes `codebase-memory-mcp` at `v0.6.0`, whose GitHub release has **no published binaries** — its auto-download 404s. Headroom's `get_cbm_path()` probes `~/.local/bin` *before* downloading, so the bootstrap drops a working **v0.8.1** build there to take over. Arch-detected and idempotent.

## Verification

- `headroom` 0.27.0 installs cleanly under Homebrew Python 3.14.
- `codebase-memory-mcp 0.8.1` runs Headroom's exact invocation (`cli index_repository '{…}'`) → `"status":"indexed"`, exit 0.
- `uvx` resolves (Serena will register on next `cc`).
- `bash -n init/install.sh` passes.

## Note

The code-graph binary is ~270 MB (normal for this Go tool). `CBM_VER` is pinned to `v0.8.1` for deterministic bootstraps; bump it when newer tagged builds ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)