### PR TITLE
Brewfile: add fathom cask (AI meeting notetaker)

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -119,6 +119,7 @@ cask '1password-cli'
 cask 'beeper'
 cask 'claude'
 cask 'cursor'
+cask 'fathom' # AI meeting notetaker (records, transcribes & summarises calls)
 cask 'font-source-sans-3'
 cask 'gcloud-cli'
 cask 'google-chrome'


### PR DESCRIPTION
Add [Fathom](https://fathom.video) — an AI meeting notetaker that records, transcribes and summarises calls — to the Brewfile as a desktop cask.

Installed locally via `brew install --cask fathom` (v3.4.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)